### PR TITLE
Fix geonames ambigues result names

### DIFF
--- a/experiments/geonames.js
+++ b/experiments/geonames.js
@@ -197,6 +197,11 @@ function updatePlaceInputs() {
                                     function(x) {
                                         return {
                                             text: x['name'] +
+                                                " (" + 
+                                                (x['toponymName'] !== x['name'] ? (x['toponymName'] + ', ') : '') + 
+                                                (x['adminName1'] !== x['name'] ? (x['adminName1'] + ', ') : '') + 
+                                                x['countryName'] + 
+                                                ")" +
                                                 "; " +
                                                 x['geonameId'],
                                             id: x['geonameId'],

--- a/experiments/staticgeonamesExample.html
+++ b/experiments/staticgeonamesExample.html
@@ -66,7 +66,7 @@
       the display entries when new inputs are selected, feel free!)</h3>
       
       This example uses the 
-      <a href="https://geonames.org">Geonames service <img alt="GeoNames logo" src="https://www.geonames.org/geonames.ico" width="16" height="16" /></a> for which you must have an account (username) and have the API usage enabled. 
+      <a href="https://geonames.org">Geonames service <img alt="GeoNames logo" src="https://www.geonames.org/geonames.ico" width="16" height="16" style="margin-left:4px;" /></a> for which you must have an account (username) and have the API usage enabled. 
       
 
       <h2>Input</h2>
@@ -81,7 +81,7 @@
                role="textbox"
                data-cvoc-protocol="geonames"
                data-cvoc-vocabs="{"geonames":{"uriSpace":"https://sws.geonames.org/"}}"
-               data-cvoc-allowfreetext="false"
+               data-cvoc-allowfreetext="true"
                lang=""
                data-cvoc-headers="{}"
                data-cvoc-filter=""
@@ -140,6 +140,30 @@ $(document).ready(function() {
     updatePlaceInputs(); // This is the input part (autocomplete dropdown)
 });
 
+// This function formats the place name for display
+// It uses the place object to construct a string
+function getFormattedPlacename(place) {
+    var name = place.name;
+
+    let nameDetailsArray = [];
+
+    if (place.toponymName && place.toponymName !== place.name) {
+        nameDetailsArray.push(place.toponymName);
+    }
+    if (place.adminName1 && place.adminName1 !== place.name) {
+        nameDetailsArray.push(place.adminName1);
+    }
+    if (place.countryName) {
+        nameDetailsArray.push(place.countryName);
+    }
+
+    if (nameDetailsArray.length > 0) {
+        // If there are additional details, append them in parentheses
+        name += " (" + nameDetailsArray.join(', ') + ")";
+    }
+    return name;
+}
+
 // For displaying the places; expanding the info for the geonames IDs
 function expandPlaces() {
     // Check each selected element
@@ -169,11 +193,12 @@ function expandPlaces() {
                     success: function(place, status) {
                         // If found, construct the HTML for display
                         // extract the name from the JSON response
-                        var name = place.name; //place.name['family-name'].value + ", " + place.name['given-names'].value;
+                        //var name = place.name; //place.name['family-name'].value + ", " + place.name['given-names'].value;
+                        var name = getFormattedPlacename(place);
                         // Note there is no logo for geonames service so we just use the geonames site icon
                         var displayElement = $('<span/>').text(name).append($('<a/>').attr('href', 'https://sws.geonames.org/' + id)
                                             .attr('target', '_blank').attr('rel', 'noopener')
-                                            .html('<img alt="Geoname logo?" src="https://www.geonames.org/geonames.ico" width="16" height="16" />'));
+                                            .html('<img alt="Geoname logo?" src="https://www.geonames.org/geonames.ico" width="16" height="16" style="margin-left:4px;" />'));
                         $(placeElement).hide();
                         let sibs = $(placeElement).siblings("[data-cvoc-index='" + $(placeElement).attr('data-cvoc-index') + "']");
                         if (sibs.length == 0) {
@@ -240,13 +265,15 @@ function updatePlaceInputs() {
             $(placeInput).attr('data-place', num);
             //Todo: if not displayed, wait until it is to then create the select 2 with a non-zero width
 
+            let allowFreeText = ($(placeInput).attr('data-cvoc-allowfreetext') == 'true');
+
             //Add a select2 element to allow search and provide a list of choices
             var selectId = "personAddSelect_" + num;
             $(placeInput).parent().parent().children('div').eq(0).append(
                 '<select id=' + selectId + ' class="form-control add-resource select2" tabindex="0">');
             $("#" + selectId).select2({
                 theme: "classic",
-                tags: $(placeInput).attr('data-cvoc-allowfreetext'),
+                tags: allowFreeText,
                 delay: 500,
                 templateResult: function(item) {
                     // No need to template the searching text
@@ -317,14 +344,7 @@ function updatePlaceInputs() {
                                 .map(
                                     function(x) {
                                         return {
-                                            text: x['name'] +
-                                                " (" + 
-                                                (x['toponymName'] !== x['name'] ? (x['toponymName'] + ', ') : '') + 
-                                                (x['adminName1'] !== x['name'] ? (x['adminName1'] + ', ') : '') + 
-                                                x['countryName'] + 
-                                                ")" +
-                                                "; " +
-                                                x['geonameId'],
+                                            text: getFormattedPlacename(x) + "; " + x['geonameId'], 
                                             id: x['geonameId'],
                                             //Since clicking in the selection re-opens the choice list, one has to use a right click/open in new tab/window to view the ORCID page
                                             //Using title to provide that hint as a popup
@@ -364,7 +384,7 @@ function updatePlaceInputs() {
                     },
                     success: function(place, status) {
                         // extract the name from the JSON response
-                        var name = place.name;
+                        var name = getFormattedPlacename(place);
                         var text = name + "; " + id;
                         var newOption = new Option(text, id, true, true);
                         newOption.title = 'Open in new tab to view geonames page';

--- a/experiments/staticgeonamesExample.html
+++ b/experiments/staticgeonamesExample.html
@@ -81,7 +81,7 @@
                role="textbox"
                data-cvoc-protocol="geonames"
                data-cvoc-vocabs="{"geonames":{"uriSpace":"https://sws.geonames.org/"}}"
-               data-cvoc-allowfreetext="true"
+               data-cvoc-allowfreetext="false"
                lang=""
                data-cvoc-headers="{}"
                data-cvoc-filter=""
@@ -128,7 +128,6 @@
 // Hardcode it here for now
 // NOTE: Replace with real value!
 var geonamesUsername = "your_geonames_username"; // kind of an API key for the Geonames service
-
 
 // Note that these selectors should match the Dataverse CVOC configuration
 var placeSelector = "span[data-cvoc-protocol='geonames']";
@@ -319,6 +318,11 @@ function updatePlaceInputs() {
                                     function(x) {
                                         return {
                                             text: x['name'] +
+                                                " (" + 
+                                                (x['toponymName'] !== x['name'] ? (x['toponymName'] + ', ') : '') + 
+                                                (x['adminName1'] !== x['name'] ? (x['adminName1'] + ', ') : '') + 
+                                                x['countryName'] + 
+                                                ")" +
                                                 "; " +
                                                 x['geonameId'],
                                             id: x['geonameId'],


### PR DESCRIPTION
Display of the geonames selection must get more details appended used for disambiguation of locations. 
Using the geonames JSON result for a location we did only use the 'name' but we should now add the following after the name: 
 " (toponymName, adminName1, countryName)"
We need to handle the posisbilty that one ore several of those values are not avaiable or empty. 
Also, when the toponymName and or the adminName1 are the same as the name (like with Utrecht) we don't want them to repeat this. 